### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
This is to avoid below error in Jenkins build

[ERROR] error: Source option 6 is no longer supported. Use 7 or later.
[ERROR] error: Target option 6 is no longer supported. Use 7 or later.